### PR TITLE
Added Key vault and Function app role assignment for Key Vault Secrets User

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -348,7 +348,7 @@
                         "value": "[reference(concat(variables('functionAppName'), '-', parameters('utcValue'))).outputs.managedServiceIdentityId.value]"
                     },
                     "assignmentType": {
-                        "value": "Key Vault Crypto Officer"
+                        "value": "Key Vault Secrets User"
                     },
                     "resourceName": {
                         "value": "[variables('keyVaultName')]"

--- a/azure/template.json
+++ b/azure/template.json
@@ -79,6 +79,7 @@
         "resourceGroupName": "[concat(variables('resourceNamePrefix'), '-rg')]",
         "functionAppName": "[concat(variables('resourceNamePrefix'), '-fa')]",
         "appServicePlanName": "[concat(variables('resourceNamePrefix'), '-asp')]",
+        "keyVaultName": "[concat(variables('resourceNamePrefix'),'-kv')]",
         "configNames": "SFA.DAS.Courses.Jobs"
     },
     "resources": [
@@ -282,6 +283,75 @@
                 "parameters": {
                     "functionAppName": {
                         "value": "[variables('functionAppName')]"
+                    }
+                }
+            },
+            "dependsOn": [
+                "[concat(variables('functionAppName'), '-', parameters('utcValue'))]"
+            ]
+        },
+        {
+            "apiVersion": "2021-04-01",
+            "name": "[concat(variables('keyVaultName'), '-', parameters('utcValue'))]",
+            "type": "Microsoft.Resources/deployments",
+            "resourceGroup": "[variables('resourceGroupName')]",
+            "properties": {
+                "mode": "Incremental",
+                "templateLink": {
+                    "uri": "[concat(variables('deploymentUrlBase'),'keyvault.json')]",
+                    "contentVersion": "1.0.0.0"
+                },
+                "parameters": {
+                    "keyVaultName": {
+                        "value": "[variables('keyVaultName')]"
+                    },
+                    "enabledForTemplateDeployment": {
+                        "value": false
+                    },
+                    "enableFirewall": {
+                        "value": true
+                    },
+                    "enableRbacAuthorization": {
+                        "Value": true
+                    },
+                    "subnetResourceIdList": {
+                        "value": [ "[reference(concat(parameters('subnetObject').name, '-', parameters('utcValue'))).outputs.SubnetResourceId.value]" ]
+                    },
+                    "allowTrustedMicrosoftServices": {
+                        "value": false
+                    },
+                    "logAnalyticsWorkspaceName": {
+                        "value": "[parameters('logAnalyticsWorkspaceName')]"
+                    },
+                    "logAnalyticsWorkspaceResourceGroupName": {
+                        "value": "[parameters('sharedManagementResourceGroup')]"
+                    }
+                }
+            },
+            "dependsOn": [
+                "[variables('resourceGroupName')]"
+            ]
+        },
+        {
+            "apiVersion": "2022-09-01",
+            "name": "[concat('role-assignment-', variables('functionAppName'),'-', variables('keyVaultName'))]",
+            "type": "Microsoft.Resources/deployments",
+            "resourceGroup": "[variables('resourceGroupName')]",
+            "properties": {
+                "mode": "Incremental",
+                "templateLink": {
+                    "uri": "[uri(variables('deploymentUrlBase'),'role-assignments/role-assignment-key-vault.json')]",
+                    "contentVersion": "1.0.0.0"
+                },
+                "parameters": {
+                    "principalId": {
+                        "value": "[reference(concat(variables('functionAppName'), '-', parameters('utcValue'))).outputs.managedServiceIdentityId.value]"
+                    },
+                    "assignmentType": {
+                        "value": "Key Vault Crypto Officer"
+                    },
+                    "resourceName": {
+                        "value": "[variables('keyVaultName')]"
                     }
                 }
             },


### PR DESCRIPTION
Devs require a key vault which can be accessed using the MI authority for the das-courses-jobs function app das-<environrment>-crswkr-fa.

Dev will be generating a fine grained access token for GitHub and storing it in the key vault so that the function app can access the key from there instead of from storage configuration.